### PR TITLE
Prevent reloading of settings page at saving or syncing.

### DIFF
--- a/src/main/resources/templates/global_admin.vm
+++ b/src/main/resources/templates/global_admin.vm
@@ -38,7 +38,7 @@
 
    <fieldset class="group">
     <div class="aui-buttons">
-     <button class="aui-button aui-button-primary ssfb-save">Save</button>
+     <button type="button" class="aui-button aui-button-primary ssfb-save">Save</button>
     </div>
     <div class="description">
      Sync-settings in all repos will be reset to these settings.
@@ -54,7 +54,7 @@
    </legend>
 
    <div class="aui-buttons">
-    <button class="aui-button aui-button-primary ssfb-sync-now">Sync now</button>
+    <button type="button" class="aui-button aui-button-primary ssfb-sync-now">Sync now</button>
    </div>
    <div class="description">
     Settings in all repos will be reset to their master repo. You may want to save before you sync, if the repos does not already have sync-settings.

--- a/src/main/resources/templates/repo_admin.vm
+++ b/src/main/resources/templates/repo_admin.vm
@@ -48,8 +48,8 @@
 
    <fieldset class="group">
     <div class="aui-buttons">
-     <button class="aui-button aui-button-primary ssfb-save">Save</button>
-     <button class="aui-button ssfb-sync-now">Sync now</button>
+     <button type="button" class="aui-button aui-button-primary ssfb-save">Save</button>
+     <button type="button" class="aui-button ssfb-sync-now">Sync now</button>
     </div>
    </fieldset>
 


### PR DESCRIPTION
Some browsers like Firefox do not wait for event handler callbacks to
finish when a navigation event has been propagated.
This behavior prevents the execution of the settings sync, which
executes the sync after saving.
To mitigate this the type of the HTML button elements are set to
'button' (default: 'submit') which does not propagate a navigation
event.